### PR TITLE
Print 'no error's message to see some progress

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Optional arguments:
 * ``--schema SCHEMA`` the schema to validate against
 * ``--check-urls`` check the HTTP status code if "format": "uri"
 * ``--timeout TIMEOUT`` timeout (seconds) to GET a URL
+* ``--verbose`` print also the items with no validation errors
 
 ::
 

--- a/ocdskit/cli/commands/validate.py
+++ b/ocdskit/cli/commands/validate.py
@@ -20,6 +20,7 @@ class Command(BaseCommand):
                           default='http://standard.open-contracting.org/latest/en/release-package-schema.json')
         self.add_argument('--check-urls', help='check the HTTP status code if "format": "uri"', action='store_true')
         self.add_argument('--timeout', help='timeout (seconds) to GET a URL', type=int, default=10)
+        self.add_argument('--verbose', help='print also the items with no validation errors', action='store_true')
 
     def handle(self):
         components = urlparse(self.args.schema)
@@ -51,7 +52,11 @@ class Command(BaseCommand):
         for i, line in enumerate(self.buffer()):
             try:
                 data = json.loads(line)
+                errors = False
                 for error in validator(schema, format_checker=format_checker).iter_errors(data):
                     print('item {}: {} ({})'.format(i, error.message, '/'.join(error.absolute_schema_path)))
+                    errors = True
+                if not errors and self.args.verbose:
+                    print('item {}: no errors'.format(i))
             except json.decoder.JSONDecodeError as e:
                 raise CommandError('item {}: JSON error: {}'.format(i, e))

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -61,6 +61,18 @@ def test_command_valid_release_package_file(monkeypatch):
     assert actual.getvalue() == ''
 
 
+def test_command_valid_release_package_file_verbose(monkeypatch):
+    url = 'file://{}'.format(os.path.realpath(os.path.join('tests', 'fixtures', 'release-package-schema.json')))
+
+    stdin = read('realdata/release-package-1.json', 'rb')
+
+    with patch('sys.stdin', TextIOWrapper(BytesIO(stdin))), patch('sys.stdout', new_callable=StringIO) as actual:
+        monkeypatch.setattr(sys, 'argv', ['ocdskit', 'validate', '--schema', url, '--verbose'])
+        main()
+
+    assert actual.getvalue() == 'item 0: no errors\n'
+
+
 def test_command_invalid_record_package(monkeypatch):
     url = 'http://standard.open-contracting.org/latest/en/record-package-schema.json'
 


### PR DESCRIPTION
Print no errors message for the items that validates, this is to see
some progress when running the command and not wait with the console
empty without knowing what happens.