### PR TITLE
Make schema-strict for all fields

### DIFF
--- a/docs/cli/schema.rst
+++ b/docs/cli/schema.rst
@@ -73,7 +73,7 @@ Optional arguments:
 schema-strict
 -------------
 
-For any required field, adds "minItems" if an array, "minProperties" if an object and "minLength" if a string and "enum", "format" and "pattern" are not set. For any array field, adds "uniqueItems".
+Adds "minItems" and "uniqueItems" if an array, "minProperties" if an object and "minLength" if a string and "enum", "format" and "pattern" are not set.
 
 Optional arguments:
 

--- a/ocdskit/cli/commands/schema_strict.py
+++ b/ocdskit/cli/commands/schema_strict.py
@@ -3,8 +3,8 @@ from ocdskit.cli.commands.base import BaseCommand
 
 class Command(BaseCommand):
     name = 'schema-strict'
-    help = 'for any required field, adds "minItems" if an array, "minProperties" if an object and "minLength" if a ' \
-           'string and "enum", "format" and "pattern" are not set, and for any array field, adds "uniqueItems"'
+    help = 'adds "minItems" and "uniqueItems" if an array, "minProperties" if an object and "minLength" if a ' \
+           'string and "enum", "format" and "pattern" are not set'
 
     def add_arguments(self):
         self.add_argument('--no-unique-items', action='store_true',
@@ -16,28 +16,21 @@ class Command(BaseCommand):
                 for item in data:
                     recurse(item)
             elif isinstance(data, dict):
-                if not self.args.no_unique_items and 'type' in data and 'array' in data['type']:
-                    if 'uniqueItems' not in data:
-                        data['uniqueItems'] = True
+                if 'type' in data:
+                    if ('string' in data['type'] and 'enum' not in data and 'format' not in data
+                            and 'pattern' not in data):
+                        if 'minLength' not in data:
+                            data['minLength'] = 1
+                    if 'array' in data['type']:
+                        if 'minItems' not in data:
+                            data['minItems'] = 1
+                        if not self.args.no_unique_items:
+                            if 'uniqueItems' not in data:
+                                data['uniqueItems'] = True
 
-                if 'required' in data:
-                    for name in data['required']:
-                        definition = data['properties'][name]
-                        if 'type' in definition:
-                            definition_type = definition['type']
-                        else:
-                            definition_type = []
-
-                        if ('string' in definition_type and 'enum' not in definition and 'format' not in definition
-                                and 'pattern' not in definition):
-                            if 'minLength' not in definition:
-                                definition['minLength'] = 1
-                        if 'array' in definition_type:
-                            if 'minItems' not in definition:
-                                definition['minItems'] = 1
-                        if 'object' in definition_type:
-                            if 'minProperties' not in definition:
-                                definition['minProperties'] = 1
+                    if 'object' in data['type']:
+                        if 'minProperties' not in data:
+                            data['minProperties'] = 1
 
                 for value in data.values():
                     recurse(value)

--- a/tests/commands/test_schema_strict.py
+++ b/tests/commands/test_schema_strict.py
@@ -79,6 +79,7 @@ expected = '''{
   "properties": {
     "optionalArray": {
       "type": "array",
+      "minItems": 1,
       "uniqueItems": true
     },
     "array": {
@@ -92,7 +93,8 @@ expected = '''{
       "uniqueItems": true
     },
     "optionalObject": {
-      "type": "object"
+      "type": "object",
+      "minProperties": 1
     },
     "object": {
       "type": "object",
@@ -103,7 +105,8 @@ expected = '''{
       "minProperties": 2
     },
     "optionalString": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "string": {
       "type": "string",


### PR DESCRIPTION
Ref https://github.com/open-contracting/ocds-extensions/issues/102

I left the string type conditions as they are, I hope that's OK.